### PR TITLE
Addition of more DAO testing

### DIFF
--- a/orderbookProject/orderbookTestDB.SQL
+++ b/orderbookProject/orderbookTestDB.SQL
@@ -31,6 +31,3 @@ CREATE TABLE trade(
   CONSTRAINT fk_buyer_id FOREIGN KEY (buyerId) REFERENCES `client`(clientId),
   CONSTRAINT fk_seller_id FOREIGN KEY (sellerId) REFERENCES `client`(clientId)
 );
-
-INSERT INTO client (name) VALUES ("Pied Piper");
-INSERT INTO client (name) VALUES ("Hooli");

--- a/orderbookProject/orderbookTestDB.SQL
+++ b/orderbookProject/orderbookTestDB.SQL
@@ -23,9 +23,9 @@ CREATE TABLE orderTable(
 CREATE TABLE trade(
   tradeId INT PRIMARY KEY AUTO_INCREMENT,
   buyerId INT,
-  buyerPrice DECIMAL,
+  buyerPrice DECIMAL(20,10),
   sellerId INT,
-  sellerPrice DECIMAL,
+  sellerPrice DECIMAL(20,10),
   quantityFilled INT,
   executionTime TIMESTAMP,
   CONSTRAINT fk_buyer_id FOREIGN KEY (buyerId) REFERENCES `client`(clientId),

--- a/orderbookProject/src/main/java/app/dao/ClientDao.java
+++ b/orderbookProject/src/main/java/app/dao/ClientDao.java
@@ -5,7 +5,7 @@ import app.dto.Client;
 import java.util.List;
 
 public interface ClientDao {
-    List<Client> getAllClient();
+    List<Client> getAllClients();
 
     boolean deleteClientById(int clientId);
 

--- a/orderbookProject/src/main/java/app/dao/ClientDao.java
+++ b/orderbookProject/src/main/java/app/dao/ClientDao.java
@@ -7,6 +7,8 @@ import java.util.List;
 public interface ClientDao {
     List<Client> getAllClients();
 
+    Client getClientById(int clientId);
+
     boolean deleteClientById(int clientId);
 
     Client addClient(Client newClient);

--- a/orderbookProject/src/main/java/app/dao/ClientDaoDB.java
+++ b/orderbookProject/src/main/java/app/dao/ClientDaoDB.java
@@ -19,7 +19,7 @@ public class ClientDaoDB implements ClientDao{
   public ClientDaoDB(JdbcTemplate jdbcTemplate) { this.jdbc = jdbcTemplate; }
 
   @Override
-  public List<Client> getAllClient() {
+  public List<Client> getAllClients() {
     final String SELECT_ALL_CLIENTS = "SELECT * FROM client";
     return jdbc.query(SELECT_ALL_CLIENTS, new ClientMapper());
   }

--- a/orderbookProject/src/main/java/app/dao/ClientDaoDB.java
+++ b/orderbookProject/src/main/java/app/dao/ClientDaoDB.java
@@ -3,14 +3,17 @@ package app.dao;
 import app.dto.Client;
 import app.dto.Order;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.support.GeneratedKeyHolder;
+import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.sql.*;
 import java.util.List;
 
+@Repository
 public class ClientDaoDB implements ClientDao{
 
   private final JdbcTemplate jdbc;
@@ -22,6 +25,16 @@ public class ClientDaoDB implements ClientDao{
   public List<Client> getAllClients() {
     final String SELECT_ALL_CLIENTS = "SELECT * FROM client";
     return jdbc.query(SELECT_ALL_CLIENTS, new ClientMapper());
+  }
+
+  @Override
+  public Client getClientById(int clientId) {
+    try{
+      final String SELECT_CLIENT_BY_ID = "SELECT * FROM client WHERE clientId = ?";
+      return jdbc.queryForObject(SELECT_CLIENT_BY_ID, new ClientMapper(), clientId);
+    } catch (DataAccessException ex) {
+      return null;
+    }
   }
 
   @Override

--- a/orderbookProject/src/main/java/app/dao/TradeDao.java
+++ b/orderbookProject/src/main/java/app/dao/TradeDao.java
@@ -7,5 +7,6 @@ import java.util.List;
 public interface TradeDao {
     List<Trade> getAllTrades();
     Trade addTrade(Trade newTrade);
+    Trade getTradeById(int tradeId);
     boolean deleteTrade(int tradeId);
 }

--- a/orderbookProject/src/main/java/app/dao/TradeDaoDB.java
+++ b/orderbookProject/src/main/java/app/dao/TradeDaoDB.java
@@ -2,6 +2,7 @@ package app.dao;
 
 import app.dto.Trade;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.support.GeneratedKeyHolder;
@@ -50,6 +51,16 @@ public class TradeDaoDB implements TradeDao{
 
         newTrade.setTradeId(keyholder.getKey().intValue());
         return newTrade;
+    }
+
+    @Override
+    public Trade getTradeById(int tradeId) {
+        try{
+            final String SELECT_CLIENT_BY_ID = "SELECT * FROM client WHERE clientId = ?";
+            return jdbc.queryForObject(SELECT_CLIENT_BY_ID, new TradeMapper(), tradeId);
+        } catch (DataAccessException ex) {
+            return null;
+        }
     }
 
     @Override

--- a/orderbookProject/src/main/java/app/dao/TradeDaoDB.java
+++ b/orderbookProject/src/main/java/app/dao/TradeDaoDB.java
@@ -5,11 +5,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.support.GeneratedKeyHolder;
+import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.sql.*;
 import java.util.List;
 
+@Repository
 public class TradeDaoDB implements TradeDao{
 
     private final JdbcTemplate jdbc;

--- a/orderbookProject/src/main/java/app/dao/TradeDaoDB.java
+++ b/orderbookProject/src/main/java/app/dao/TradeDaoDB.java
@@ -31,7 +31,7 @@ public class TradeDaoDB implements TradeDao{
     @Override
     @Transactional
     public Trade addTrade(Trade newTrade) {
-        final String INSERT_TRADE = "INSERT INTO table(buyerId, buyerPrice, sellerId, sellerPrice, quantityFilled) VALUES(?,?,?,?,?)";
+        final String INSERT_TRADE = "INSERT INTO trade(buyerId, buyerPrice, sellerId, sellerPrice, quantityFilled) VALUES(?,?,?,?,?)";
 
         GeneratedKeyHolder keyholder = new GeneratedKeyHolder();
 
@@ -45,7 +45,6 @@ public class TradeDaoDB implements TradeDao{
             statement.setInt(3, newTrade.getSellerId());
             statement.setBigDecimal(4, newTrade.getSellerPrice());
             statement.setInt(5, newTrade.getQuantityFilled());
-
             return statement;
         }, keyholder);
 
@@ -56,8 +55,8 @@ public class TradeDaoDB implements TradeDao{
     @Override
     public Trade getTradeById(int tradeId) {
         try{
-            final String SELECT_CLIENT_BY_ID = "SELECT * FROM client WHERE clientId = ?";
-            return jdbc.queryForObject(SELECT_CLIENT_BY_ID, new TradeMapper(), tradeId);
+            final String SELECT_TRADE_BY_ID = "SELECT * FROM trade WHERE tradeId = ?";
+            return jdbc.queryForObject(SELECT_TRADE_BY_ID, new TradeMapper(), tradeId);
         } catch (DataAccessException ex) {
             return null;
         }
@@ -79,9 +78,7 @@ public class TradeDaoDB implements TradeDao{
             trade.setSellerId(rs.getInt("sellerId"));
             trade.setSellerPrice(rs.getBigDecimal("sellerPrice"));
             trade.setQuantityFilled(rs.getInt("quantityFilled"));
-            trade.setExecutionTime(rs.getTimestamp("executionTime"));
             return trade;
         }
     }
-
 }

--- a/orderbookProject/src/main/java/app/dto/Trade.java
+++ b/orderbookProject/src/main/java/app/dto/Trade.java
@@ -1,7 +1,9 @@
 package app.dto;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.Date;
+import java.util.Objects;
 
 public class Trade {
   private Integer tradeId;
@@ -66,5 +68,22 @@ public class Trade {
 
   public void setExecutionTime(Date executionTime) {
     this.executionTime = executionTime;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Trade trade = (Trade)o;
+    return Objects.equals(tradeId, trade.tradeId) && Objects.equals(buyerId, trade.buyerId) && Objects.equals(buyerPrice, trade.buyerPrice) && Objects.equals(sellerId, trade.sellerId) && Objects.equals(sellerPrice, trade.sellerPrice) && Objects.equals(quantityFilled, trade.quantityFilled);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(tradeId, buyerId, buyerPrice, sellerId, sellerPrice, quantityFilled);
   }
 }

--- a/orderbookProject/src/main/java/app/serviceLayer/OrderBookServiceLayerImpl.java
+++ b/orderbookProject/src/main/java/app/serviceLayer/OrderBookServiceLayerImpl.java
@@ -18,7 +18,7 @@ public class OrderBookServiceLayerImpl implements OrderBookServiceLayer{
     public Order checkValidOrder(Order order) {
         System.out.println("Compare New order to order Table");
         if (order.getOrderType().equals("Sell")) {
-            List<Order> orders = daoDB.getBuyOrders();
+            List<Order> orders = daoDB.getBuyOrders(order.getStockSymbol());
             for (Order order1 : orders) {
 
                 if(order1.getPrice().compareTo(order.getPrice()) == -1 ){
@@ -27,7 +27,7 @@ public class OrderBookServiceLayerImpl implements OrderBookServiceLayer{
                 }
             }
         } else {
-            List<Order> orders = daoDB.getSellOrders();
+            List<Order> orders = daoDB.getSellOrders(order.getStockSymbol());
             for (Order order1 : orders) {
                 if(order1.getPrice().compareTo(order.getPrice()) == 1){
                     order = order1;

--- a/orderbookProject/src/test/java/OrderBookDaoDBTest.java
+++ b/orderbookProject/src/test/java/OrderBookDaoDBTest.java
@@ -175,8 +175,8 @@ public class OrderBookDaoDBTest {
     thirdOrder.setPrice(new BigDecimal("20.00"));
     thirdOrder = orderDao.addOrder(thirdOrder);
 
-    List<Order> buyOrders = orderDao.getBuyOrders();
-    List<Order> sellOrders = orderDao.getSellOrders();
+    List<Order> buyOrders = orderDao.getBuyOrders(firstOrder.getStockSymbol());
+    List<Order> sellOrders = orderDao.getSellOrders(secondOrder.getStockSymbol());
 
     assertNotNull(buyOrders);
     assertNotNull(sellOrders);

--- a/orderbookProject/src/test/java/OrderBookDaoDBTest.java
+++ b/orderbookProject/src/test/java/OrderBookDaoDBTest.java
@@ -357,6 +357,52 @@ public class OrderBookDaoDBTest {
     assertEquals(newTrade, tradeFromDao);
   }
 
+  @Test
+  public void testGetAllTradesAndRemove() {
+    Client client = new Client();
+    client.setName("Pied Piper");
+    client = clientDao.addClient(client);
 
+    Order buyOrder = new Order();
+    buyOrder.setClientId(client.getClientId());
+    buyOrder.setOrderType("buy");
+    buyOrder.setOrderStatus("new");
+    buyOrder.setStockSymbol("TSLA");
+    buyOrder.setCumulativeQuantity(50);
+    buyOrder.setPrice(new BigDecimal("20.00"));
+    buyOrder = orderDao.addOrder(buyOrder);
+
+    Order sellOrder = new Order();
+    sellOrder.setClientId(client.getClientId());
+    sellOrder.setOrderType("sell");
+    sellOrder.setOrderStatus("new");
+    sellOrder.setStockSymbol("TSLA");
+    sellOrder.setCumulativeQuantity(50);
+    sellOrder.setPrice(new BigDecimal("20.00"));
+    sellOrder = orderDao.addOrder(sellOrder);
+
+    //Grab orders from Dao to assure not a value mismatch from the database
+    sellOrder = orderDao.getOrder(sellOrder.getOrderId());
+    buyOrder = orderDao.getOrder(buyOrder.getOrderId());
+
+    Trade newTrade = new Trade();
+    newTrade.setSellerId(sellOrder.getClientId());
+    newTrade.setSellerPrice(sellOrder.getPrice());
+    newTrade.setBuyerId(buyOrder.getClientId());
+    newTrade.setBuyerPrice(buyOrder.getPrice());
+    newTrade.setQuantityFilled(Math.min(sellOrder.getCumulativeQuantity(), buyOrder.getCumulativeQuantity()));
+    newTrade = tradeDao.addTrade(newTrade);
+
+    List<Trade> allTrades = tradeDao.getAllTrades();
+
+    assertNotNull(allTrades);
+    assertEquals(1, allTrades.size());
+    assertTrue(allTrades.contains(newTrade));
+
+    tradeDao.deleteTrade(newTrade.getTradeId());
+    allTrades = tradeDao.getAllTrades();
+    assertNotNull(allTrades);
+    assertEquals(0, allTrades.size());
+  }
 
 }

--- a/orderbookProject/src/test/java/OrderBookDaoDBTest.java
+++ b/orderbookProject/src/test/java/OrderBookDaoDBTest.java
@@ -3,8 +3,10 @@ import app.TestApplicationConfiguration;
 import app.dao.ClientDao;
 import app.dao.OrderBookDao;
 import app.dao.TradeDao;
+import app.dto.Client;
 import app.dto.Order;
 
+import app.dto.Trade;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -29,26 +31,73 @@ public class OrderBookDaoDBTest {
   @Autowired
   ClientDao clientDao;
 
-  /**
-   * TO BE REFACTORED AS DAOS ARE ADDED
-   * These test methods have hard coded clientIds that need to be created in the database before running
-   */
-
   @Before
   public void setUp() {
     List<Order> orders = orderDao.getAllOrders();
     List<Client> clients = clientDao.getAllClients();
+    List<Trade> trades = tradeDao.getAllTrades();
+
     for (Order order : orders) {
       orderDao.deleteOrderById(order.getOrderId());
     }
+    for (Client client: clients) {
+      clientDao.deleteClientById(client.getClientId());
+    }
+    for (Trade trade: trades) {
+      tradeDao.deleteTrade(trade.getTradeId());
+    }
+  }
+
+  // Client DAO testing
+  @Test
+  public void testAddGetClients() {
+    Client firstClient = new Client();
+    firstClient.setName("Pied Piper");
+    firstClient = clientDao.addClient(firstClient);
+
+    Client firstClientDao = clientDao.getClientById(firstClient.getClientId());
+
+    assertNotNull(firstClientDao);
+    assertEquals(firstClientDao, firstClient);
   }
 
   @Test
+  public void testDeleteAndGetAllClients() {
+    Client firstClient = new Client();
+    firstClient.setName("Pied Piper");
+    firstClient = clientDao.addClient(firstClient);
+
+    Client secondClient = new Client();
+    secondClient.setName("Hooli");
+    secondClient = clientDao.addClient(secondClient);
+
+    List<Client> allClients = clientDao.getAllClients();
+
+    assertNotNull(allClients);
+    assertEquals(2, allClients.size());
+    assertTrue(allClients.contains(firstClient));
+    assertTrue(allClients.contains(secondClient));
+
+    clientDao.deleteClientById(firstClient.getClientId());
+    allClients = clientDao.getAllClients();
+
+    assertNotNull(allClients);
+    assertEquals(1, allClients.size());
+    assertFalse(allClients.contains(firstClient));
+    assertTrue(allClients.contains(secondClient));
+  }
+
+  // Order DAO testing
+  @Test
   public void testAddGetOrder() {
+    Client firstClient = new Client();
+    firstClient.setName("Pied Piper");
+    firstClient = clientDao.addClient(firstClient);
+
     Order order = new Order();
-    order.setClientId(1);
-    order.setOrderType("BID");
-    order.setOrderStatus("New");
+    order.setClientId(firstClient.getClientId());
+    order.setOrderType("buy");
+    order.setOrderStatus("new");
     order.setStockSymbol("TSLA");
     order.setCumulativeQuantity(50);
     order.setPrice(new BigDecimal("20.00"));
@@ -56,116 +105,217 @@ public class OrderBookDaoDBTest {
 
     Order fromDao = orderDao.getOrder(order.getOrderId());
 
+    assertNotNull(fromDao);
     assertEquals(order, fromDao);
   }
 
   @Test
   public void testGetAllOrders() {
+    Client client = new Client();
+    client.setName("Pied Piper");
+    client = clientDao.addClient(client);
+
     // Add two new orders to the database
     Order firstOrder = new Order();
-    firstOrder.setClientId(1);
-    firstOrder.setOrderType("BID");
-    firstOrder.setOrderStatus("New");
+    firstOrder.setClientId(client.getClientId());
+    firstOrder.setOrderType("buy");
+    firstOrder.setOrderStatus("new");
     firstOrder.setStockSymbol("TSLA");
     firstOrder.setCumulativeQuantity(50);
     firstOrder.setPrice(new BigDecimal("20.00"));
     firstOrder = orderDao.addOrder(firstOrder);
 
     Order secondOrder = new Order();
-    secondOrder.setClientId(1);
-    secondOrder.setOrderType("ASK");
-    secondOrder.setOrderStatus("Canceled");
+    secondOrder.setClientId(client.getClientId());
+    secondOrder.setOrderType("sell");
+    secondOrder.setOrderStatus("canceled");
     secondOrder.setStockSymbol("TSLA");
     secondOrder.setCumulativeQuantity(35);
     secondOrder.setPrice(new BigDecimal("35.25"));
     secondOrder = orderDao.addOrder(secondOrder);
-
-    Order firstFromDao = orderDao.getOrder(firstOrder.getOrderId());
-    Order secondFromDao = orderDao.getOrder(secondOrder.getOrderId());
 
     List<Order> allOrders = orderDao.getAllOrders();
 
     assertEquals(2, allOrders.size());
-    assertTrue(allOrders.contains(firstFromDao));
-    assertTrue(allOrders.contains(secondFromDao));
+    assertTrue(allOrders.contains(firstOrder));
+    assertTrue(allOrders.contains(secondOrder));
   }
 
   @Test
-  public void testCancelAndGetCurrentOrders() {
-    // Add two new orders to the database
+  public void testGetSellAndBuyOrder() {
+    Client client = new Client();
+    client.setName("Pied Piper");
+    client = clientDao.addClient(client);
+
     Order firstOrder = new Order();
-    firstOrder.setClientId(1);
-    firstOrder.setOrderType("BID");
-    firstOrder.setOrderStatus("New");
+    firstOrder.setClientId(client.getClientId());
+    firstOrder.setOrderType("buy");
+    firstOrder.setOrderStatus("new");
     firstOrder.setStockSymbol("TSLA");
     firstOrder.setCumulativeQuantity(50);
     firstOrder.setPrice(new BigDecimal("20.00"));
     firstOrder = orderDao.addOrder(firstOrder);
 
     Order secondOrder = new Order();
-    secondOrder.setClientId(1);
-    secondOrder.setOrderType("ASK");
-    secondOrder.setOrderStatus("New");
+    secondOrder.setClientId(client.getClientId());
+    secondOrder.setOrderType("sell");
+    secondOrder.setOrderStatus("new");
     secondOrder.setStockSymbol("TSLA");
     secondOrder.setCumulativeQuantity(35);
     secondOrder.setPrice(new BigDecimal("35.25"));
     secondOrder = orderDao.addOrder(secondOrder);
 
-    Order firstFromDao = orderDao.getOrder(firstOrder.getOrderId());
-    Order secondFromDao = orderDao.getOrder(secondOrder.getOrderId());
+    Order thirdOrder = new Order();
+    thirdOrder.setClientId(client.getClientId());
+    thirdOrder.setOrderType("sell");
+    thirdOrder.setOrderStatus("canceled");
+    thirdOrder.setStockSymbol("TSLA");
+    thirdOrder.setCumulativeQuantity(50);
+    thirdOrder.setPrice(new BigDecimal("20.00"));
+    thirdOrder = orderDao.addOrder(thirdOrder);
+
+    List<Order> buyOrders = orderDao.getBuyOrders();
+    List<Order> sellOrders = orderDao.getSellOrders();
+
+    assertNotNull(buyOrders);
+    assertNotNull(sellOrders);
+    assertEquals(1, buyOrders.size());
+    assertEquals(1, sellOrders.size());
+    assertFalse(buyOrders.containsAll(sellOrders));
+    assertTrue(buyOrders.contains(firstOrder));
+    assertTrue(sellOrders.contains(secondOrder));
+    assertFalse(sellOrders.contains(thirdOrder));
+  }
+
+  @Test
+  public void testCancelAndGetCurrentOrders() {
+    Client client = new Client();
+    client.setName("Pied Piper");
+    client = clientDao.addClient(client);
+
+    // Add two new orders to the database
+    Order firstOrder = new Order();
+    firstOrder.setClientId(client.getClientId());
+    firstOrder.setOrderType("buy");
+    firstOrder.setOrderStatus("new");
+    firstOrder.setStockSymbol("TSLA");
+    firstOrder.setCumulativeQuantity(50);
+    firstOrder.setPrice(new BigDecimal("20.00"));
+    firstOrder = orderDao.addOrder(firstOrder);
+
+    Order secondOrder = new Order();
+    secondOrder.setClientId(client.getClientId());
+    secondOrder.setOrderType("sell");
+    secondOrder.setOrderStatus("new");
+    secondOrder.setStockSymbol("TSLA");
+    secondOrder.setCumulativeQuantity(35);
+    secondOrder.setPrice(new BigDecimal("35.25"));
+    secondOrder = orderDao.addOrder(secondOrder);
 
     List<Order> currentOrders = orderDao.getCurrentOrders();
 
     assertNotNull(currentOrders);
     assertEquals(2, currentOrders.size());
-    assertTrue(currentOrders.contains(firstFromDao));
-    assertTrue(currentOrders.contains(secondFromDao));
+    assertTrue(currentOrders.contains(firstOrder));
+    assertTrue(currentOrders.contains(secondOrder));
 
-    orderDao.cancelOrder(secondFromDao.getOrderId());
+    orderDao.cancelOrder(secondOrder.getOrderId());
     currentOrders = orderDao.getCurrentOrders();
 
     assertNotNull(currentOrders);
     assertEquals(1, currentOrders.size());
-    assertTrue(currentOrders.contains(firstFromDao));
-    assertFalse(currentOrders.contains(secondFromDao));
+    assertTrue(currentOrders.contains(firstOrder));
+    assertFalse(currentOrders.contains(secondOrder));
   }
 
   @Test
   public void getOrdersByClientId() {
-    // Add two new orders to the database
+    // Add clients
+    Client firstClient = new Client();
+    firstClient.setName("Pied Piper");
+    firstClient = clientDao.addClient(firstClient);
+
+    Client secondClient = new Client();
+    secondClient.setName("Hooli");
+    secondClient = clientDao.addClient(secondClient);
+
+    // Add three new orders to the database
     Order firstOrder = new Order();
-    firstOrder.setClientId(1);
-    firstOrder.setOrderType("BID");
-    firstOrder.setOrderStatus("New");
+    firstOrder.setClientId(firstClient.getClientId());
+    firstOrder.setOrderType("buy");
+    firstOrder.setOrderStatus("new");
     firstOrder.setStockSymbol("TSLA");
     firstOrder.setCumulativeQuantity(50);
     firstOrder.setPrice(new BigDecimal("20.00"));
     firstOrder = orderDao.addOrder(firstOrder);
 
     Order secondOrder = new Order();
-    secondOrder.setClientId(2);
-    secondOrder.setOrderType("ASK");
-    secondOrder.setOrderStatus("New");
+    secondOrder.setClientId(secondClient.getClientId());
+    secondOrder.setOrderType("buy");
+    secondOrder.setOrderStatus("new");
     secondOrder.setStockSymbol("TSLA");
     secondOrder.setCumulativeQuantity(35);
     secondOrder.setPrice(new BigDecimal("35.25"));
     secondOrder = orderDao.addOrder(secondOrder);
 
-    Order firstFromDao = orderDao.getOrder(firstOrder.getOrderId());
-    Order secondFromDao = orderDao.getOrder(secondOrder.getOrderId());
+    Order thirdOrder = new Order();
+    thirdOrder.setClientId(firstClient.getClientId());
+    thirdOrder.setOrderType("sell");
+    thirdOrder.setOrderStatus("new");
+    thirdOrder.setStockSymbol("TSLA");
+    thirdOrder.setCumulativeQuantity(50);
+    thirdOrder.setPrice(new BigDecimal("20.00"));
+    thirdOrder = orderDao.addOrder(thirdOrder);
 
-    List<Order> firstClient = orderDao.getOrdersByClientId(1);
-    List<Order> secondClient = orderDao.getOrdersByClientId(2);
+    // Method being tested
+    List<Order> firstClientOrders = orderDao.getOrdersByClientId(firstClient.getClientId());
 
-    assertNotNull(firstClient);
-    assertNotNull(secondClient);
-    assertEquals(1, firstClient.size());
-    assertEquals(1, secondClient.size());
-    assertTrue(firstClient.contains(firstFromDao));
-    assertFalse(firstClient.contains(secondFromDao));
-    assertTrue(secondClient.contains(secondFromDao));
-    assertFalse(secondClient.contains(firstFromDao));
+    // Assertions
+    assertNotNull(firstClientOrders);
+    assertEquals(2, firstClientOrders.size());
+    assertTrue(firstClientOrders.contains(firstOrder));
+    assertFalse(firstClientOrders.contains(secondOrder));
+    assertTrue(firstClientOrders.contains(thirdOrder));
   }
+
+  @Test
+  public void testUpdateOrder() {
+    Client firstClient = new Client();
+    firstClient.setName("Pied Piper");
+    firstClient = clientDao.addClient(firstClient);
+
+    Order originalOrder = new Order();
+    originalOrder.setClientId(firstClient.getClientId());
+    originalOrder.setOrderType("buy");
+    originalOrder.setOrderStatus("new");
+    originalOrder.setStockSymbol("TSLA");
+    originalOrder.setCumulativeQuantity(50);
+    originalOrder.setPrice(new BigDecimal("20.00"));
+    originalOrder = orderDao.addOrder(originalOrder);
+
+    // Addition of the original order id to simulate it being the same order
+    // but updated
+    Order updatedOrder = new Order();
+    updatedOrder.setOrderId(originalOrder.getOrderId());
+    updatedOrder.setClientId(firstClient.getClientId());
+    updatedOrder.setOrderType("buy");
+    updatedOrder.setOrderStatus("new");
+    updatedOrder.setStockSymbol("TSLA");
+    updatedOrder.setCumulativeQuantity(25);
+    updatedOrder.setPrice(new BigDecimal("20.00"));
+
+    orderDao.updateOrder(updatedOrder);
+    List<Order> allOrders = orderDao.getAllOrders();
+
+    assertNotNull(allOrders);
+    assertEquals(1, allOrders.size());
+    assertTrue(allOrders.contains(updatedOrder));
+    assertFalse(allOrders.contains(originalOrder));
+  }
+
+  // Trade DAO testing
+
+
 
 
 }

--- a/orderbookProject/src/test/java/OrderBookDaoDBTest.java
+++ b/orderbookProject/src/test/java/OrderBookDaoDBTest.java
@@ -1,6 +1,8 @@
 import app.TestApplicationConfiguration;
 
+import app.dao.ClientDao;
 import app.dao.OrderBookDao;
+import app.dao.TradeDao;
 import app.dto.Order;
 
 import org.junit.Before;
@@ -21,6 +23,12 @@ public class OrderBookDaoDBTest {
   @Autowired
   OrderBookDao orderDao;
 
+  @Autowired
+  TradeDao tradeDao;
+
+  @Autowired
+  ClientDao clientDao;
+
   /**
    * TO BE REFACTORED AS DAOS ARE ADDED
    * These test methods have hard coded clientIds that need to be created in the database before running
@@ -29,6 +37,7 @@ public class OrderBookDaoDBTest {
   @Before
   public void setUp() {
     List<Order> orders = orderDao.getAllOrders();
+    List<Client> clients = clientDao.getAllClients();
     for (Order order : orders) {
       orderDao.deleteOrderById(order.getOrderId());
     }


### PR DESCRIPTION
This pull request will add the remaining tests for the DAOs as well as test any functions added since the last pull request for testing.

OrderBookDao:
- [x] Autowire the renamed DAO
- [x] Add sell and buy list test
- [x] Add clients to each test so they are no longer hardcoded
- [x] Add update order test
- [x] Update the test database to have no data in it
- [x] refactor existing tests as needed

ClientDao:
- [x] Autowire the new Client DAO
- [x] Update the setup method to empty the client table
- [x] Add client test
- [x] Delete client test (to confirm setup functions)
- [x] Get all clients test

TradeDao:
- [x] Autowire the new Trade DAO
- [x] Update the setup method to empty the trade table
- [x] test for adding trades
- [x] test for deleting trades (to confirm setup functions)
- [x] test for get all trades